### PR TITLE
Add SGX_IOC_ENABLE_FSGSBASE IOCTL

### DIFF
--- a/sgx_ioctl.c
+++ b/sgx_ioctl.c
@@ -72,6 +72,7 @@
 #include <linux/slab.h>
 #include <linux/hashtable.h>
 #include <linux/shmem_fs.h>
+#include <asm/tlbflush.h>
 
 static int sgx_get_encl(unsigned long addr, struct sgx_encl **encl)
 {
@@ -96,6 +97,16 @@ static int sgx_get_encl(unsigned long addr, struct sgx_encl **encl)
 
 	up_read(&mm->mmap_sem);
 	return ret;
+}
+
+static void __enable_fsgsbase(void *v)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
+	write_cr4(read_cr4() | X86_CR4_FSGSBASE);
+#else
+	cr4_set_bits(X86_CR4_FSGSBASE);
+	__write_cr4(__read_cr4() | X86_CR4_FSGSBASE);
+#endif
 }
 
 /**
@@ -251,6 +262,26 @@ out:
 	return ret;
 }
 
+/**
+ * sgx_ioc_enable_fsgsbase - handler for %SGX_IOC_ENABLE_FSGSBASE
+ * @filep:	open file to /dev/sgx
+ * @cmd:	the command value
+ * @arg:	not used
+ *
+ * Enables FSGSBASE access in CR4.
+ *
+ * Return:
+ * 0 on success,
+ * system error on failure
+ */
+static long sgx_ioc_enable_fsgsbase(struct file *filep, unsigned int cmd,
+				   unsigned long arg)
+{
+	__enable_fsgsbase(NULL);
+	smp_call_function(__enable_fsgsbase, NULL, 1);
+	return 0;
+}
+
 typedef long (*sgx_ioc_t)(struct file *filep, unsigned int cmd,
 			  unsigned long arg);
 
@@ -270,12 +301,17 @@ long sgx_ioctl(struct file *filep, unsigned int cmd, unsigned long arg)
 	case SGX_IOC_ENCLAVE_INIT:
 		handler = sgx_ioc_enclave_init;
 		break;
+	case SGX_IOC_ENABLE_FSGSBASE:
+		handler = sgx_ioc_enable_fsgsbase;
+		break;
 	default:
 		return -ENOIOCTLCMD;
 	}
 
-	if (copy_from_user(data, (void __user *)arg, _IOC_SIZE(cmd)))
-		return -EFAULT;
+	if (cmd & IOC_IN) {
+		if (copy_from_user(data, (void __user *)arg, _IOC_SIZE(cmd)))
+			return -EFAULT;
+	}
 
 	ret = handler(filep, cmd, (unsigned long)((void *)data));
 	if (!ret && (cmd & IOC_OUT)) {

--- a/sgx_ioctl.c
+++ b/sgx_ioctl.c
@@ -110,7 +110,7 @@ static void enable_fsgsbase(void *v)
 
 /**
  * sgx_ioc_enclave_create - handler for %SGX_IOC_ENCLAVE_CREATE
- * @filep:	open file to /dev/sgx
+ * @filep:	open file to /dev/isgx
  * @cmd:	the command value
  * @arg:	pointer to the &struct sgx_enclave_create
  *
@@ -148,7 +148,7 @@ static long sgx_ioc_enclave_create(struct file *filep, unsigned int cmd,
 /**
  * sgx_ioc_enclave_add_page - handler for %SGX_IOC_ENCLAVE_ADD_PAGE
  *
- * @filep:	open file to /dev/sgx
+ * @filep:	open file to /dev/isgx
  * @cmd:	the command value
  * @arg:	pointer to the &struct sgx_enclave_add_page
  *
@@ -206,7 +206,7 @@ out:
 /**
  * sgx_ioc_enclave_init - handler for %SGX_IOC_ENCLAVE_INIT
  *
- * @filep:	open file to /dev/sgx
+ * @filep:	open file to /dev/isgx
  * @cmd:	the command value
  * @arg:	pointer to the &struct sgx_enclave_init
  *
@@ -263,7 +263,7 @@ out:
 
 /**
  * sgx_ioc_enable_fsgsbase - handler for %SGX_IOC_ENABLE_FSGSBASE
- * @filep:	open file to /dev/sgx
+ * @filep:	open file to /dev/isgx
  * @cmd:	the command value
  * @arg:	not used
  *

--- a/sgx_ioctl.c
+++ b/sgx_ioctl.c
@@ -99,13 +99,12 @@ static int sgx_get_encl(unsigned long addr, struct sgx_encl **encl)
 	return ret;
 }
 
-static void __enable_fsgsbase(void *v)
+static void enable_fsgsbase(void *v)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
 	write_cr4(read_cr4() | X86_CR4_FSGSBASE);
 #else
 	cr4_set_bits(X86_CR4_FSGSBASE);
-	__write_cr4(__read_cr4() | X86_CR4_FSGSBASE);
 #endif
 }
 
@@ -271,14 +270,13 @@ out:
  * Enables FSGSBASE access in CR4.
  *
  * Return:
- * 0 on success,
- * system error on failure
+ * 0
  */
 static long sgx_ioc_enable_fsgsbase(struct file *filep, unsigned int cmd,
-				   unsigned long arg)
+				    unsigned long arg)
 {
-	__enable_fsgsbase(NULL);
-	smp_call_function(__enable_fsgsbase, NULL, 1);
+	enable_fsgsbase(NULL);
+	smp_call_function(enable_fsgsbase, NULL, true);
 	return 0;
 }
 

--- a/sgx_user.h
+++ b/sgx_user.h
@@ -69,6 +69,8 @@
 	_IOW(SGX_MAGIC, 0x01, struct sgx_enclave_add_page)
 #define SGX_IOC_ENCLAVE_INIT \
 	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init)
+#define SGX_IOC_ENABLE_FSGSBASE \
+	_IO(SGX_MAGIC, 0x03)
 
 /* SGX leaf instruction return values */
 #define SGX_SUCCESS			0

--- a/sgx_user.h
+++ b/sgx_user.h
@@ -70,7 +70,7 @@
 #define SGX_IOC_ENCLAVE_INIT \
 	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init)
 #define SGX_IOC_ENABLE_FSGSBASE \
-	_IO(SGX_MAGIC, 0x03)
+	_IO(SGX_MAGIC, 0x0e)
 
 /* SGX leaf instruction return values */
 #define SGX_SUCCESS			0


### PR DESCRIPTION
This IOCTL enables access to FSGSBASE in CR4. Having such access simplifies
exception handling and TLS access for applications that don't use the SGX SDK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/omeg/linux-sgx-driver/1)
<!-- Reviewable:end -->
